### PR TITLE
Print Loop Logs only during havocing.

### DIFF
--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -168,7 +168,9 @@ ExecutionState::ExecutionState(const ExecutionState& state):
   for(auto it = havocs.begin(); it != havocs.end(); ++it) {
     it->first->refCount++;
   }
-  LOG_LA("Cloning ES " << (void*)this << " from " << (void*)&state);
+  if (!loopInProcess.isNull()) {
+    LOG_LA("Cloning ES " << (void *)this << " from " << (void *)&state);
+  }
 }
 
 void ExecutionState::addHavocInfo(const MemoryObject *mo,


### PR DESCRIPTION
Printing irrespective of whether there is a loopInProcess is confusing to walk through.